### PR TITLE
add a Util class with a toPath method

### DIFF
--- a/src/Phlash/AbstractCollection.php
+++ b/src/Phlash/AbstractCollection.php
@@ -9,7 +9,7 @@ use Iterator;
 use JsonSerializable;
 use Phlash\Str;
 
-abstract class AbstractCollection implements ArrayAccess, Countable, Iterator, JsonSerializable
+abstract class AbstractCollection extends AbstractPhlashClass implements ArrayAccess, Countable, Iterator, JsonSerializable
 {
     use ArrayAccessTrait,
         CountableTrait,

--- a/src/Phlash/AbstractPhlashClass.php
+++ b/src/Phlash/AbstractPhlashClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Phlash;
+
+abstract class AbstractPhlashClass
+{
+    const VERSION = '0.7.0';
+}
+

--- a/src/Phlash/Func.php
+++ b/src/Phlash/Func.php
@@ -4,7 +4,7 @@ namespace Phlash;
 
 use Closure;
 
-abstract class Func
+abstract class Func extends AbstractPhlashClass
 {
     /**
      * Calls the supplied function bound to the given $thisArg with the array of arguments.

--- a/src/Phlash/Util.php
+++ b/src/Phlash/Util.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phlash;
+
+abstract class Util extends AbstractPhlashClass
+{
+    /**
+     * @var string  Regex to match path values
+     */
+    const TO_PATH_REGEX = '/(\w)+|(\d)+/';
+
+    /**
+     * Destructure a path array from a path string
+     *
+     * @param  string  $value
+     * @return array
+     */
+    public static function toPath(string $value = '') : array
+    {
+        if (empty($value))
+            return [];
+
+        $out = [];
+
+        preg_match_all(static::TO_PATH_REGEX, $value, $out);
+
+        return $out[0] ?? [];
+    }
+}
+

--- a/test/Phlash/ToPathTest.php
+++ b/test/Phlash/ToPathTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phlash\Tests;
+
+use Phlash\Util;
+
+class ToPathTest extends TestCase
+{
+    public function testToPath()
+    {
+        $this->assertEquals(['a', '0', 'bar'], Util::toPath('a[0].bar'));
+        $this->assertEquals(['0', '1', '2'], Util::toPath('[0][1][2]'));
+        $this->assertEquals(['foo', 'bar', 'fooBar'], Util::toPath('foo.bar.fooBar'));
+    }
+}
+


### PR DESCRIPTION
Closes #96 

- Adds a `Util` class w/ a `toPath` method
- Adds tests for `Util::toPath`
- Adds an `AbstractPhlashClass` class as a common ancestor for all `Phlash` classes